### PR TITLE
enhancement in saving attachments

### DIFF
--- a/src/pst/attachment.clj
+++ b/src/pst/attachment.clj
@@ -34,4 +34,5 @@
 (defn save
   "Given an attachment and a filename, save attached file contents to disk."
   [a fn]
-  (copy (.getFileInputStream (:java-object a)) (output-stream fn)))
+  (with-open [out (output-stream file)]
+    (copy (.getFileInputStream (:java-object a)) out)))

--- a/src/pst/attachment.clj
+++ b/src/pst/attachment.clj
@@ -34,5 +34,5 @@
 (defn save
   "Given an attachment and a filename, save attached file contents to disk."
   [a fn]
-  (with-open [out (output-stream file)]
+  (with-open [out (output-stream fn)]
     (copy (.getFileInputStream (:java-object a)) out)))


### PR DESCRIPTION
When I used pst in my project, attachments were not saved properly. I noticed that jvm was still holding the file handle. I noticed that the output stream is not closed properly, so I have wrapped it in with-open. Now it works like a charm. Please let me know what you think.